### PR TITLE
Make commands

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,5 @@
+const fs = require('fs-extra')
+const path = require('path')
 const cli = require('commander')
 const importCwd = require('import-cwd')
 const Project = require('./commands/new')
@@ -10,8 +12,32 @@ module.exports = () => {
     .action((path, repo, cmdObj) => Project.scaffold(path, repo, cmdObj))
 
   cli
+    .command('make:layout <filename>')
+    .option('-d, --dir <dir>', 'directory where the file should be output')
+    .description('scaffold a new Layout')
+    .action((filename, cmdObj) => {
+      if (path.parse(filename).ext === '') {
+        throw(`Error: <filename> argument must have an extension, i.e. ${filename}.html`)
+      }
+
+      try {
+        const layout = fs.readFileSync(`${__dirname}/stubs/layout.njk`, 'utf-8')
+        const destination = cmdObj.dir ? path.resolve(`${cmdObj.dir}/${filename}`) : path.resolve(`${process.cwd()}/src/layouts/${filename}`)
+
+        if (fs.existsSync(destination)) {
+          throw(`Error: ${destination} already exists.`)
+        }
+
+        fs.outputFileSync(destination, layout)
+        console.log(`✔ Successfully created new Layout in ${destination}`)
+      } catch (error) {
+        throw error
+      }
+    })
+
+  cli
     .command('build [env]')
-    .description(`compile email templates and output them to disk`)
+    .description('compile email templates and output them to disk')
     .action(env => {
       try {
         const Maizzle = importCwd('./bootstrap')
@@ -23,7 +49,7 @@ module.exports = () => {
 
   cli
     .command('serve')
-    .description(`start a local development server and watch for file changes`)
+    .description('start a local development server and watch for file changes')
     .action(() => {
       try {
         const Maizzle = importCwd('./bootstrap')

--- a/src/index.js
+++ b/src/index.js
@@ -45,14 +45,14 @@ module.exports = () => {
       }
 
       try {
-        const layout = fs.readFileSync(`${__dirname}/stubs/template.njk`, 'utf-8')
+        const template = fs.readFileSync(`${__dirname}/stubs/template.njk`, 'utf-8')
         const destination = cmdObj.dir ? path.resolve(`${cmdObj.dir}/${filename}`) : path.resolve(`${process.cwd()}/src/templates/${filename}`)
 
         if (fs.existsSync(destination)) {
           throw(`Error: ${destination} already exists.`)
         }
 
-        fs.outputFileSync(destination, layout)
+        fs.outputFileSync(destination, template)
         console.log(`✔ Successfully created new Template in ${destination}`)
       } catch (error) {
         throw error

--- a/src/index.js
+++ b/src/index.js
@@ -13,7 +13,7 @@ module.exports = () => {
 
   cli
     .command('make:layout <filename>')
-    .option('-d, --dir <dir>', 'directory where the file should be output')
+    .option('-d, --directory <dir>', 'directory where the file should be output')
     .description('scaffold a new Layout')
     .action((filename, cmdObj) => {
       if (path.parse(filename).ext === '') {
@@ -22,7 +22,7 @@ module.exports = () => {
 
       try {
         const layout = fs.readFileSync(`${__dirname}/stubs/layout.njk`, 'utf-8')
-        const destination = cmdObj.dir ? path.resolve(`${cmdObj.dir}/${filename}`) : path.resolve(`${process.cwd()}/src/layouts/${filename}`)
+        const destination = cmdObj.directory ? path.resolve(`${cmdObj.directory}/${filename}`) : path.resolve(`${process.cwd()}/src/layouts/${filename}`)
 
         if (fs.existsSync(destination)) {
           throw(`Error: ${destination} already exists.`)
@@ -37,7 +37,7 @@ module.exports = () => {
 
   cli
     .command('make:template <filename>')
-    .option('-d, --dir <dir>', 'directory where the file should be output')
+    .option('-d, --directory <dir>', 'directory where the file should be output')
     .description('scaffold a new Template')
     .action((filename, cmdObj) => {
       if (path.parse(filename).ext === '') {
@@ -46,7 +46,7 @@ module.exports = () => {
 
       try {
         const template = fs.readFileSync(`${__dirname}/stubs/template.njk`, 'utf-8')
-        const destination = cmdObj.dir ? path.resolve(`${cmdObj.dir}/${filename}`) : path.resolve(`${process.cwd()}/src/templates/${filename}`)
+        const destination = cmdObj.directory ? path.resolve(`${cmdObj.directory}/${filename}`) : path.resolve(`${process.cwd()}/src/templates/${filename}`)
 
         if (fs.existsSync(destination)) {
           throw(`Error: ${destination} already exists.`)

--- a/src/index.js
+++ b/src/index.js
@@ -36,6 +36,30 @@ module.exports = () => {
     })
 
   cli
+    .command('make:template <filename>')
+    .option('-d, --dir <dir>', 'directory where the file should be output')
+    .description('scaffold a new Template')
+    .action((filename, cmdObj) => {
+      if (path.parse(filename).ext === '') {
+        throw(`Error: <filename> argument must have an extension, i.e. ${filename}.html`)
+      }
+
+      try {
+        const layout = fs.readFileSync(`${__dirname}/stubs/template.njk`, 'utf-8')
+        const destination = cmdObj.dir ? path.resolve(`${cmdObj.dir}/${filename}`) : path.resolve(`${process.cwd()}/src/templates/${filename}`)
+
+        if (fs.existsSync(destination)) {
+          throw(`Error: ${destination} already exists.`)
+        }
+
+        fs.outputFileSync(destination, layout)
+        console.log(`✔ Successfully created new Template in ${destination}`)
+      } catch (error) {
+        throw error
+      }
+    })
+
+  cli
     .command('build [env]')
     .description('compile email templates and output them to disk')
     .action(env => {

--- a/src/index.js
+++ b/src/index.js
@@ -60,6 +60,27 @@ module.exports = () => {
     })
 
   cli
+    .command('make:config <env>')
+    .option('-f, --full', 'scaffold a full config')
+    .description('scaffold a new Config')
+    .action((env, cmdObj) => {
+      try {
+        const config = fs.readFileSync(`${__dirname}/stubs/config/${cmdObj.full ? 'full' : 'base'}.js`, 'utf-8')
+        const destination = path.resolve(`${process.cwd()}/config.${env}.js`)
+
+        if (fs.existsSync(destination)) {
+          throw(`Error: ${destination} already exists.`)
+        }
+
+        const configString = config.replace('build_local', `build_${env}`)
+        fs.outputFileSync(destination, configString)
+        console.log(`✔ Successfully created new Config in ${destination}`)
+      } catch (error) {
+        throw error
+      }
+    })
+
+  cli
     .command('build [env]')
     .description('compile email templates and output them to disk')
     .action(env => {

--- a/src/stubs/config/base.js
+++ b/src/stubs/config/base.js
@@ -1,0 +1,7 @@
+module.exports = {
+  build: {
+    destination: {
+      path: 'build_local',
+    },
+  },
+}

--- a/src/stubs/config/full.js
+++ b/src/stubs/config/full.js
@@ -1,0 +1,108 @@
+module.exports = {
+  doctype: 'html',
+  language: 'en',
+  charset: 'utf-8',
+  googleFonts: '',
+  baseImageURL: '',
+  inlineCSS: {
+    enabled: false,
+    styleToAttribute: {
+      'background-color': 'bgcolor',
+      'background-image': 'background',
+      'text-align': 'align',
+      'vertical-align': 'valign',
+    },
+    applySizeAttribute: {
+      width: [],
+      height: [],
+    },
+    excludedProperties: null,
+  },
+  cleanup: {
+    purgeCSS: {
+      content: [
+        'src/layouts/**/*.*',
+        'src/partials/**/*.*',
+        'src/components/**/*.*',
+      ],
+      whitelist: [],
+      whitelistPatterns: [],
+    },
+    removeUnusedCSS: {
+      enabled: false,
+    },
+    replaceStrings: false,
+    keepOnlyAttributeSizes: {
+      width: [],
+      height: [],
+    },
+    preferBgColorAttribute: false,
+  },
+  applyExtraAttributes: {
+    table: {
+      cellpadding: 0,
+      cellspacing: 0,
+      role: 'presentation',
+    },
+    img: {
+      alt: ''
+    }
+  },
+  urlParameters: {},
+  prettify: {
+    enabled: false,
+    indent_inner_html: false,
+    ocd: true,
+  },
+  minify: {
+    enabled: false,
+  },
+  browsersync: {
+    directory: true,
+    notify: false,
+    open: false,
+    port: 3000,
+    tunnel: false,
+    watch: [
+      'src/layouts/**/*.*',
+      'src/partials/**/*.*',
+      'src/components/**/*.*',
+    ],
+  },
+  markdown: {
+    baseUrl: null,
+    breaks: false,
+    gfm: true,
+    headerIds: false,
+    headerPrefix: '',
+    highlight: null,
+    langPrefix: 'language-',
+    mangle: true,
+    pendantic: false,
+    sanitize: false,
+    sanitizer: null,
+    silent: false,
+    smartLists: false,
+    smartypants: false,
+    tables: true,
+    xhtml: false
+  },
+  build: {
+    destination: {
+      path: 'build_local',
+      extension: 'html',
+    },
+    templates: {
+      source: 'src/templates',
+      filetypes: 'html|njk|nunjucks',
+    },
+    tailwind: {
+      css: 'src/assets/css/main.css',
+      config: 'tailwind.config.js',
+    },
+    assets: {
+      source: 'src/assets/images',
+      destination: 'images',
+    },
+  },
+}

--- a/src/stubs/layout.njk
+++ b/src/stubs/layout.njk
@@ -1,0 +1,32 @@
+<!DOCTYPE {{ page.doctype or 'html' }}>
+<html {% if page.htmlClass %}class="{{ page.htmlClass }}"{% endif %} lang="{{ page.language or 'en' }}" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
+<head>
+  <meta charset="{{ page.charset or 'utf-8' }}">
+  <meta http-equiv="x-ua-compatible" content="ie=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="x-apple-disable-message-reformatting">
+  {% if page.title %}<title>{{ page.title }}</title>{% endif %}
+  {% if page.googleFonts %}<link href="https://fonts.googleapis.com/css?family={{ page.googleFonts }}" rel="stylesheet" media="screen">{%- endif %}
+  <!--[if mso]>
+  <xml>
+    <o:OfficeDocumentSettings>
+      <o:PixelsPerInch>96</o:PixelsPerInch>
+    </o:OfficeDocumentSettings>
+  </xml>
+  <style>
+    table {border-collapse: collapse;}
+    td,th,div,p,a,h1,h2,h3,h4,h5,h6 {font-family: "Segoe UI", sans-serif; mso-line-height-rule: exactly;}
+  </style>
+  <![endif]-->
+  {% if css %}<style>{{ css }}</style>{% endif %}
+  {% block head %}{% endblock %}
+</head>
+<body {% if page.bodyClass %}class="{{ page.bodyClass }}"{% endif %}>
+{% if page.preheader %}
+  <div class="hidden">{{ page.preheader }}</div>
+{% endif %}
+
+{% block template %}{% endblock %}
+</body>
+</html>
+

--- a/src/stubs/template.njk
+++ b/src/stubs/template.njk
@@ -1,0 +1,9 @@
+---
+title: "Example title"
+---
+
+{% extends "src/layouts/default.njk" %}
+
+{% block template %}
+
+{% endblock %}


### PR DESCRIPTION
This PR adds 3 new CLI commands:

## `make:layout [-d|--directory]?` 

Scaffolds a new Layout at an optional `--directory` path. If the path provided in the `--directory` option does not exist, it will be created.

Example:

```sh
# scaffold a Layout in src/layouts
maizzle make:layout my-layout.njk

# use a custom directory
maizzle make:layout my-layout.njk --directory=src/layouts/amp

# the above is the same as
maizzle make:layout my-layout.njk -d=src/layouts/amp

# paths can be relative to project root, i.e. one level above
maizzle make:layout my-layout.njk -d=../amp-layouts
```

## `make:template --directory?` 

Scaffolds a new Template at an optional `--directory` path. `--directory` option usage is identical to `make:layout` above.

## `make:config <env>` 

Scaffolds a new `config.<env>.js` in the project root. `<env>` is the environment name, i.e. `staging`.

By default, a minimal config is output, which only defines the `build.destination.path`: 

```js
module.exports = {
  build: {
    destination: {
      path: 'build_staging',
    },
  },
}
```

For a full config, use the `--full` option. The full config is based on the [Starter's config.js](https://github.com/maizzle/maizzle/blob/master/config.js), and has comments removed.

Example:

```sh
# outputs minimal `config.staging.js`
maizzle make:config staging

# outputs full `config,staging.js`
maizzle make:config staging --full

# shorter `--full` option
maizzle make:config staging -f
```

---

For all commands, if the target file already exists it will _not_ be overwritten, and an error will be thrown.