### PR TITLE
Update notifier

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7253,8 +7253,7 @@
     "semver": {
       "version": "7.3.2",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
-      "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
-      "dev": true
+      "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ=="
     },
     "semver-diff": {
       "version": "3.1.1",
@@ -8239,11 +8238,6 @@
           "requires": {
             "escape-goat": "^2.0.0"
           }
-        },
-        "semver": {
-          "version": "7.3.2",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
-          "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -35,20 +35,20 @@
     "release": "np"
   },
   "dependencies": {
-    "chalk": "^4.0.0",
-    "commander": "^6.0.0",
-    "execa": "^4.0.0",
+    "chalk": "^4.1.0",
+    "commander": "^6.2.0",
+    "execa": "^4.1.0",
     "fs-extra": "^9.0.0",
     "import-cwd": "^3.0.0",
-    "inquirer": "^7.1.0",
+    "inquirer": "^7.3.3",
     "np": "*",
-    "ora": "^5.0.0",
+    "ora": "^5.1.0",
     "update-notifier": "^5.0.1"
   },
   "devDependencies": {
-    "ava": "^3.8.0",
-    "nyc": "^15.0.1",
-    "xo": "^0.34.1"
+    "ava": "^3.13.0",
+    "nyc": "^15.1.0",
+    "xo": "^0.34.2"
   },
   "nyc": {
     "exclude": [

--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
     "import-cwd": "^3.0.0",
     "inquirer": "^7.1.0",
     "np": "*",
-    "ora": "^5.0.0"
+    "ora": "^5.0.0",
+    "update-notifier": "^5.0.1"
   },
   "devDependencies": {
     "ava": "^3.8.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@maizzle/cli",
   "version": "1.0.4",
-  "description": "CLI app for the Maizzle Email Framework",
+  "description": "CLI tool for the Maizzle Email Framework",
   "license": "MIT",
   "bin": {
     "maizzle": "./bin/maizzle"
@@ -15,13 +15,16 @@
   "author": "Cosmin Popovici (https://github.com/cossssmin)",
   "keywords": [
     "maizzle",
-    "email",
     "tailwindcss",
-    "email-framework",
     "responsive-email",
+    "email-framework",
     "email-template",
+    "email-marketing",
+    "email-campaigns",
+    "email-newsletter",
     "email-boilerplate",
-    "email-campaigns"
+    "html-emails",
+    "email-cli"
   ],
   "publishConfig": {
     "access": "public"

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,7 @@ const importCwd = require('import-cwd')
 const Project = require('./commands/new')
 const Config = require('./commands/make/config')
 const Layout = require('./commands/make/layout')
+const updateNotifier = require('update-notifier')
 const Template = require('./commands/make/template')
 
 module.exports = () => {
@@ -33,7 +34,14 @@ module.exports = () => {
   program
     .command('build [env]')
     .description('compile email templates and output them to disk')
-    .action(env => importCwd('./node_modules/@maizzle/framework/src').build(env))
+    .action(async env => {
+      await importCwd('./node_modules/@maizzle/framework/src').build(env)
+
+      updateNotifier({
+        pkg: importCwd('./node_modules/@maizzle/framework/package.json'),
+        shouldNotifyInNpmScript: true
+      }).notify()
+    })
 
   program
     .command('serve')

--- a/src/index.js
+++ b/src/index.js
@@ -68,4 +68,9 @@ module.exports = () => {
     })
 
   program.parse(process.argv)
+
+  updateNotifier({
+    pkg: require('../package.json'),
+    shouldNotifyInNpmScript: true
+  }).notify()
 }

--- a/test/test-build.js
+++ b/test/test-build.js
@@ -2,7 +2,7 @@ const test = require('ava')
 const execa = require('execa')
 
 test('throws if not in project (build)', async t => {
-  const {stderr} = await t.throwsAsync(execa.command('node bin/maizzle build'))
+  const {stderr} = await execa.command('node bin/maizzle build')
 
   t.truthy(stderr.includes('Cannot find module'))
 })


### PR DESCRIPTION
This PR adds [`update-notifier`](https://www.npmjs.com/package/update-notifier) which will notify you of framework and CLI tool updates.

The `updateCheckInterval` used is the default one - 1 day.