### PR TITLE
Changing the starter question to be clearer

### DIFF
--- a/src/commands/new.js
+++ b/src/commands/new.js
@@ -18,7 +18,7 @@ module.exports.scaffold = async (starter, directory, options, command) => {
         {
           name: 'starter',
           type: 'confirm',
-          message: 'Do you want to use a custom Starter',
+          message: 'Do you want to use a starter',
           default: false
         },
         {

--- a/src/commands/new.js
+++ b/src/commands/new.js
@@ -18,7 +18,7 @@ module.exports.scaffold = async (starter, directory, options, command) => {
         {
           name: 'starter',
           type: 'confirm',
-          message: 'Do you want to use a starter',
+          message: 'Do you want to use a Starter',
           default: false
         },
         {


### PR DESCRIPTION
Hey hey! :slightly_smiling_face: 

I was somewhat confused by the CLI message "Do you want to use a custom Starter".

Is this a starter from the official starters? Or is a custom starter a blank project?
Why would an official starter be custom? Later when I customize it, sure, but during init?

I propose to change this to "Do you want to use a starter". 

Have a wonderful day!