### PR TITLE
fix: resolving of maizzle framework

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -44,12 +44,12 @@ module.exports = () => {
     .option('-b, --bin [bin]', 'path to the maizzle executable')
     .description('compile email templates and output them to disk')
     .action(async (env, options) => {
-      const bin = options.bin || './node_modules/@maizzle/framework/src'
+      const bin = options.bin || require.resolve('@maizzle/framework/src')
 
       await importCwd(bin).build(env)
 
       updateNotifier({
-        pkg: importCwd('./node_modules/@maizzle/framework/package.json'),
+        pkg: importCwd(require.resolve('@maizzle/framework/package.json')),
         shouldNotifyInNpmScript: true,
       }).notify()
     })
@@ -60,7 +60,7 @@ module.exports = () => {
     .option('-nc, --noclear [noclear]', 'do not clear the console log')
     .description('start a local development server and watch for file changes')
     .action((env, options) => {
-      const bin = options.bin || './node_modules/@maizzle/framework/src'
+      const bin = options.bin || require.resolve('@maizzle/framework/src')
 
       importCwd(bin).serve(env, {
         build: {
@@ -80,7 +80,7 @@ module.exports = () => {
       const pkg = require('../package.json')
 
       try {
-        const maizzle = importCwd('./node_modules/@maizzle/framework/package.json')
+        const maizzle = importCwd(require.resolve('@maizzle/framework/package.json'))
         console.log(`Framework v${maizzle.version}\nCLI v${pkg.version}`)
       } catch {
         console.log(`CLI v${pkg.version}\nTo see your Framework version, run this command in the root directory of a Maizzle project.`)


### PR DESCRIPTION
This uses `require.resolve()` to attempt to resolve `@maizzle/framework` instead of using a string.

How `require.resolve` works is it uses node's internal module resolution to find the absolute path. The issue that this fixes is in #198 I use a monorepo and maizzle is running in a package inside that repo, so `./node_modules` doesn't exist and trying to run update notifier fails even if you use `--bin` flag as it doesn't take that into consideration.

I've also wrapped the default value if no `--bin` flag with `require.resolve` also as that will find it up the tree as needed too.

closes #198 