### PR TITLE
fix(make:layout): use resolvable imports in Layout stub

### DIFF
--- a/src/commands/make/stubs/Layout.vue
+++ b/src/commands/make/stubs/Layout.vue
@@ -1,8 +1,7 @@
 <script setup lang="ts">
 import { computed, useAttrs, createStaticVNode, type PropType } from 'vue'
 import { twMerge } from 'tailwind-merge'
-import { outlookFallbackProp } from './utils.ts'
-import { useOutlookFallback } from '../composables/useOutlookFallback'
+import { useOutlookFallback } from '@maizzle/framework'
 
 defineOptions({ inheritAttrs: false })
 
@@ -65,7 +64,10 @@ const props = defineProps({
    *
    * @default true
    */
-  outlookFallback: outlookFallbackProp,
+  outlookFallback: {
+    type: Boolean,
+    default: null,
+  },
 })
 
 const outlookFallback = useOutlookFallback(props.outlookFallback)


### PR DESCRIPTION
## Problem

`make:layout` scaffolds a stub that imports two framework internals via relative paths:

```js
import { outlookFallbackProp } from './utils.ts'
import { useOutlookFallback } from '../composables/useOutlookFallback'
```

These only resolve from inside `node_modules/@maizzle/framework/dist/components/`. The CLI places the file at `./components` by default, so both paths dangle and a fresh `maizzle build` crashes immediately:

```
Error: Failed to load url ./utils.ts ... Does the file exist?
```

## Fix

- Import `useOutlookFallback` from the public `@maizzle/framework` entrypoint (it's already exported there).
- Inline the `outlookFallback` prop definition into `defineProps()`. `outlookFallbackProp` isn't on the public entrypoint, and Vue's `<script setup>` compiler rejects `defineProps()` referencing a locally-declared `const`, so it has to be inlined.

Closes #331

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Outlook fallback handling in generated layouts.
  * Ensured the Outlook fallback option is recognized consistently when configuring layout output.
  * Preserved the existing default behavior when the option is not specified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->